### PR TITLE
Make melange-core LID files match library name.

### DIFF
--- a/melange-core/x86-darwin-melange-core.lid
+++ b/melange-core/x86-darwin-melange-core.lid
@@ -1,4 +1,4 @@
-library: melange-c
+library: melange-core
 unique-id-base: 10000
 target-type: dll
 files: library

--- a/melange-core/x86-freebsd-melange-core.lid
+++ b/melange-core/x86-freebsd-melange-core.lid
@@ -1,4 +1,4 @@
-library: melange-c
+library: melange-core
 unique-id-base: 10000
 target-type: dll
 files: library

--- a/melange-core/x86-linux-melange-core.lid
+++ b/melange-core/x86-linux-melange-core.lid
@@ -1,4 +1,4 @@
-library: melange-c
+library: melange-core
 unique-id-base: 10000
 target-type: dll
 files: library

--- a/melange-core/x86-win32-melange-core.lid
+++ b/melange-core/x86-win32-melange-core.lid
@@ -1,4 +1,4 @@
-library: melange-c
+library: melange-core
 unique-id-base: 10000
 target-type: dll
 files: library

--- a/melange-core/x86_64-darwin-melange-core.lid
+++ b/melange-core/x86_64-darwin-melange-core.lid
@@ -1,4 +1,4 @@
-library: melange-c
+library: melange-core
 unique-id-base: 10000
 target-type: dll
 files: library

--- a/melange-core/x86_64-linux-melange-core.lid
+++ b/melange-core/x86_64-linux-melange-core.lid
@@ -1,4 +1,4 @@
-library: melange-c
+library: melange-core
 unique-id-base: 10000
 target-type: dll
 files: library


### PR DESCRIPTION
This just removes a warning due to the LID library: line not matching the library name.
