### PR TITLE
Generate a pointer superclasses if specified by the user

### DIFF
--- a/melange-core/c-decl-write-c-ffi.dylan
+++ b/melange-core/c-decl-write-c-ffi.dylan
@@ -101,8 +101,22 @@ define method write-declaration (decl :: <pointer-declaration>, back-end :: <c-f
  => ();
   unless (decl.dylan-name = decl.referent.dylan-name)
     register-written-name(back-end.written-names, decl.dylan-name, decl);
-    format(back-end.stream, "define C-pointer-type %s => %s;\n",
-           decl.dylan-name, decl.referent.dylan-name);
+
+    let stream = back-end.stream;
+
+    if (decl.superclasses)
+      let dylan-temp-name = concatenate("<_", decl.simple-name, ">");
+      format(stream, "define C-pointer-type %s => %s;\n", dylan-temp-name, decl.referent.dylan-name);
+
+      let supers = remove!(decl.superclasses, "<statically-typed-pointer>", test: \=);
+      supers := add!(supers, dylan-temp-name);
+      format(stream, "define C-subtype %s (%s) end;\n\n",
+             decl.dylan-name, join(supers, ", "));
+
+    else
+      format(stream, "define C-pointer-type %s => %s;\n",
+             decl.dylan-name, decl.referent.dylan-name);
+    end if;
   end;
 end;
 


### PR DESCRIPTION
(Just so you can give me advice)

When trying to generate the bindings for libetpan, I need to specify a superclass for a `clist *` structure. At the moment melange generates the superclasses for the referenced struct only, this doesn't allow a nice integration between dylan and the library. For example when implemeting the f-i-p.

In this patch I generate a temporary pointer type, then a new c type that has as parents the specified superclasses and the temporary pointer type.
This should do the trick, at least from a quick test I did by manually changing the generated code.
