### PR TITLE
Insert empty token for empty macro arguments.

### DIFF
--- a/melange-core/library.dylan
+++ b/melange-core/library.dylan
@@ -92,6 +92,11 @@ define module c-lexer
   use %strings,
     import: { make-substring-positioner };
   use multistring-match;
+
+  use print;
+  use format-out;
+  use dylan-extensions;
+
   create cpp-parse;
   export
     *framework-paths*, find-frameworks,

--- a/tests/test.empty-macro-arg/empty-macro-arg.h
+++ b/tests/test.empty-macro-arg/empty-macro-arg.h
@@ -1,0 +1,25 @@
+
+#define MANGLE(module, name) module ## name
+#define DEFUN(name, module, args) extern void MANGLE(module, name) args
+
+DEFUN(foo,, (int num));
+DEFUN(bar, stdlib, (int num));
+
+#define MULTICONCAT(x, y, z) x ## y ## z
+
+MULTICONCAT(v, oi, d) baz1();
+MULTICONCAT(vo, , id) baz2();
+MULTICONCAT(vo, id, ) baz3();
+MULTICONCAT(, vo, id) baz4();
+MULTICONCAT(void, , ) baz5();
+MULTICONCAT(, void, ) baz6();
+MULTICONCAT(, , void) baz7();
+
+#define DEFUN2(flags, type, name) flags type name ()
+
+DEFUN2(extern, int, getpid);
+DEFUN2(, extern int, foobar1);
+DEFUN2(extern int, , foobar2);
+
+#define __MATHCALL(function,suffix, args) extern double function ## suffix args 
+__MATHCALL (acos,, (int __x));

--- a/tests/test.empty-macro-arg/expected.dylan
+++ b/tests/test.empty-macro-arg/expected.dylan
@@ -1,0 +1,61 @@
+module: test-empty-macro-arg
+
+define C-function foo
+  input parameter num_ :: <C-signed-int>;
+  c-name: "foo";
+end;
+
+define C-function stdlibbar
+  input parameter num_ :: <C-signed-int>;
+  c-name: "stdlibbar";
+end;
+
+define C-function baz1
+  c-name: "baz1";
+end;
+
+define C-function baz2
+  c-name: "baz2";
+end;
+
+define C-function baz3
+  c-name: "baz3";
+end;
+
+define C-function baz4
+  c-name: "baz4";
+end;
+
+define C-function baz5
+  c-name: "baz5";
+end;
+
+define C-function baz6
+  c-name: "baz6";
+end;
+
+define C-function baz7
+  c-name: "baz7";
+end;
+
+define C-function getpid
+  result res :: <C-signed-int>;
+  c-name: "getpid";
+end;
+
+define C-function foobar1
+  result res :: <C-signed-int>;
+  c-name: "foobar1";
+end;
+
+define C-function foobar2
+  result res :: <C-signed-int>;
+  c-name: "foobar2";
+end;
+
+define C-function acos
+  input parameter __x_ :: <C-signed-int>;
+  result res :: <C-double>;
+  c-name: "acos";
+end;
+

--- a/tests/test.empty-macro-arg/test.intr
+++ b/tests/test.empty-macro-arg/test.intr
@@ -1,0 +1,9 @@
+module: test-empty-macro-arg
+
+define interface
+  #include {
+      "empty-macro-arg.h"
+    },
+    import: all;
+end interface;
+


### PR DESCRIPTION
This prevents the concatenation operator (##) from erroneously
consuming the next token when trying to concatenate an empty
macro argument with some prefix.

Needed for parsing math.h/mathcalls.h on Linux, fixes #27.