### PR TITLE
Change URL to improve git protocol security

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "ext/command-line-parser"]
 	path = ext/command-line-parser
-	url = git://github.com/dylan-lang/command-line-parser.git
+	url = https://github.com/dylan-lang/command-line-parser.git
 [submodule "ext/xml-parser"]
 	path = ext/xml-parser
 	url = https://github.com/dylan-lang/xml-parser.git


### PR DESCRIPTION
As a result of GitHub's most recent Improving Git protocol security,
which was released on January 11, 2022, Final brownout.