### PR TITLE
Fix #34 Build documentation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "ext/meta"]
 	path = ext/meta
 	url = https://github.com/dylan-lang/meta.git
+[submodule "ext/sphinx-extensions"]
+	path = ext/sphinx-extensions
+	url = https://github.com/dylan-lang/sphinx-extensions

--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -12,12 +12,14 @@
 # serve to show the default.
 
 import sys, os
-import sphinxcontrib.dylan.themes as dylan_themes
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #sys.path.insert(0, os.path.abspath('.'))
+sys.path.insert(0, os.path.abspath('../../ext/sphinx-extensions/sphinxcontrib'))
+
+import dylan.themes as dylan_themes
 
 # -- General configuration -----------------------------------------------------
 
@@ -26,7 +28,7 @@ import sphinxcontrib.dylan.themes as dylan_themes
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinxcontrib.dylan.domain']
+extensions = ['dylan.domain']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
To build the documentation:

- Add submodule `sphinx-extensions` in directory `ext/`

- Add `sphinx-extensions` directory to python path.